### PR TITLE
Fixes SEC-313: Flip table emoticon is too large

### DIFF
--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -205,7 +205,7 @@ function secupress_get_scanner_counts( $type = '' ) {
 		$counts['grade'] = 'I';
 	} elseif ( $counts['percent'] >= 10 ) { // 6 less
 		$counts['grade'] = 'J';
-	} elseif ( 0 === $counts['percent'] ) { // (ᕗ‶⇀︹↼)ᕗノ彡┻━┻
+	} elseif ( 0 === $counts['percent'] ) { // (ᕗ‶⇀︹↼)ᕗ彡┻━┻
 		$counts['grade'] = '∅';
 	} else {
 		$counts['grade'] = 'K'; // < 10 %
@@ -254,7 +254,7 @@ function secupress_get_scanner_counts( $type = '' ) {
 			$counts['text'] = __( 'Very very, really very bad.', 'secupress' );
 			break;
 		case '∅':
-			$counts['text'] = '(ᕗ‶⇀︹↼)ᕗノ彡┻━┻'; // Easter egg if you got 0% (how is this possible oO).
+			$counts['text'] = '(ᕗ‶⇀︹↼)ᕗ彡┻━┻'; // Easter egg if you got 0% (how is this possible oO).
 			break;
 	}
 


### PR DESCRIPTION
Let's send the table less far to prevent it to fall a floor lower. I think it's the most important commit we ever did on SecuPress.