### PR TITLE
Fixes SEC-363: fatal error when autofixing

### DIFF
--- a/inc/admin/notices.php
+++ b/inc/admin/notices.php
@@ -444,7 +444,8 @@ function secupress_updates_message( $plugin_data ) {
 	if ( ! isset( $body[ $slug ] ) ) {
 
 		$urls = array(
-			'secupress'     => 'https://plugins.svn.wordpress.org/secupress/trunk/readme.txt',
+			'secupress'     => SECUPRESS_WEB_MAIN . '/api/plugin/readme-free.php',
+			// 'secupress'     => 'https://plugins.svn.wordpress.org/secupress/trunk/readme.txt', // Ok when on repo ////.
 			'secupress-pro' => SECUPRESS_WEB_MAIN . '/api/plugin/readme-pro.php',
 		);
 		$response = wp_remote_get( $urls[ $plugin_data['slug'] ] );

--- a/inc/admin/notices.php
+++ b/inc/admin/notices.php
@@ -444,8 +444,7 @@ function secupress_updates_message( $plugin_data ) {
 	if ( ! isset( $body[ $slug ] ) ) {
 
 		$urls = array(
-			'secupress'     => SECUPRESS_WEB_MAIN . '/api/plugin/readme-free.php',
-			// 'secupress'     => 'https://plugins.svn.wordpress.org/secupress/trunk/readme.txt', // Ok when on repo ////.
+			'secupress'     => 'https://plugins.svn.wordpress.org/secupress/trunk/readme.txt',
 			'secupress-pro' => SECUPRESS_WEB_MAIN . '/api/plugin/readme-pro.php',
 		);
 		$response = wp_remote_get( $urls[ $plugin_data['slug'] ] );

--- a/inc/common.php
+++ b/inc/common.php
@@ -323,9 +323,9 @@ add_action( 'plugins_loaded', 'secupress_rename_admin_username_logout', 50 );
  * @since 1.0
  */
 function secupress_rename_admin_username_logout() {
-	global $current_user, $pagenow, $wpdb;
+	global $current_user, $wpdb;
 
-	if ( ! empty( $_POST ) || defined( 'DOING_AJAX' ) || defined( 'DOING_AUTOSAVE' ) || defined( 'DOING_CRON' ) || 'admin-post.php' === $pagenow || ! is_user_logged_in() ) { // WPCS: CSRF ok.
+	if ( ! secupress_can_perform_extra_fix_action() ) {
 		return;
 	}
 
@@ -389,9 +389,9 @@ add_action( 'plugins_loaded', 'secupress_add_cookiehash_muplugin', 50 );
  * @since 1.0
  */
 function secupress_add_cookiehash_muplugin() {
-	global $current_user, $pagenow, $wpdb;
+	global $current_user, $wpdb;
 
-	if ( ! empty( $_POST ) || defined( 'DOING_AJAX' ) || defined( 'DOING_AUTOSAVE' ) || defined( 'DOING_CRON' ) || 'admin-post.php' === $pagenow || ! is_user_logged_in() ) { // WPCS: CSRF ok.
+	if ( ! secupress_can_perform_extra_fix_action() ) {
 		return;
 	}
 
@@ -453,9 +453,9 @@ add_action( 'plugins_loaded', 'secupress_add_salt_muplugin', 50 );
  * @since 1.0
  */
 function secupress_add_salt_muplugin() {
-	global $current_user, $pagenow, $wpdb;
+	global $current_user, $wpdb;
 
-	if ( ! empty( $_POST ) || defined( 'SECUPRESS_SALT_KEYS_ACTIVE' ) || defined( 'DOING_AJAX' ) || defined( 'DOING_AUTOSAVE' ) || defined( 'DOING_CRON' ) || 'admin-post.php' === $pagenow || ! is_user_logged_in() ) { // WPCS: CSRF ok.
+	if ( defined( 'SECUPRESS_SALT_KEYS_ACTIVE' ) || ! secupress_can_perform_extra_fix_action() ) {
 		return;
 	}
 
@@ -580,7 +580,7 @@ function secupress_auto_username_login() {
 
 
 /**
- * Used in secupress_rename_admin_username_login() to force a user when auto authenticating
+ * Used in secupress_rename_admin_username_login() to force a user when auto authenticating.
  *
  * @since 1.0
  *
@@ -602,7 +602,7 @@ add_action( 'plugins_loaded', 'secupress_downgrade_author_administrator', 70 );
  * @since 1.0
  */
 function secupress_downgrade_author_administrator() {
-	if ( ! is_admin() ) {
+	if ( ! is_admin() || ! is_user_logged_in() ) {
 		return;
 	}
 

--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -269,6 +269,19 @@ function secupress_get_scanner_counts( $type = '' ) {
 }
 
 
+/**
+ * Tell if we can perform "extra fix actions" (something we do on page reload after a fix is done).
+ *
+ * @since 1.2.3
+ *
+ * @return (bool)
+ */
+function secupress_can_perform_extra_fix_action() {
+	global $pagenow;
+	return empty( $_POST ) && ! defined( 'DOING_AJAX' ) && ! defined( 'DOING_AUTOSAVE' ) && is_admin() && 'admin-post.php' !== $pagenow && is_user_logged_in(); // WPCS: CSRF ok.
+}
+
+
 /** --------------------------------------------------------------------------------------------- */
 /** PLUGINS ===================================================================================== */
 /** --------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
Introduced `secupress_can_perform_extra_fix_action()`.
Perform the "extra fix actions" only on the admin side: it will prevent the use of `secupress_fixit()` on the front side, and trigger a fatal error (function doesn't exist).