### PR TITLE
Fixes SEC-343: Scan messages missing link to related module

### DIFF
--- a/inc/classes/scanners/class-secupress-scan-anti-scanner.php
+++ b/inc/classes/scanners/class-secupress-scan-anti-scanner.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Anti_Scanner extends SecuPress_Scan implements SecuPress_Sc
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0.1';
+	const VERSION = '1.0.2';
 
 
 	/** Properties. ============================================================================= */
@@ -39,7 +39,7 @@ class SecuPress_Scan_Anti_Scanner extends SecuPress_Scan implements SecuPress_Sc
 	 */
 	protected function init() {
 		$this->title    = __( 'Check if automated bot scanners can target your website.', 'secupress' );
-		$this->more     = __( 'Automated scanners require the contents of three page reloads to be identical. By showing them different content for each request, the scannerwill not be possible for it to work properly.', 'secupress' );
+		$this->more     = __( 'Automated scanners require the contents of three page reloads to be identical. By showing them different content for each request, the scanner will not be possible for it to work properly.', 'secupress' );
 		$this->more_fix = sprintf(
 			__( 'Activate the option %1$s in the %2$s module.', 'secupress' ),
 			'<em>' . __( 'Block SQLi Scan Attempts', 'secupress' ) . '</em>',
@@ -58,12 +58,18 @@ class SecuPress_Scan_Anti_Scanner extends SecuPress_Scan implements SecuPress_Sc
 	 * @return (string|array) A message if a message ID is provided. An array containing all messages otherwise.
 	 */
 	public static function get_messages( $message_id = null ) {
+		/** Translators: 1 is the name of a protection, 2 is the name of a module. */
+		$activate_protection_message = sprintf( __( 'But you can activate the %1$s protection from the module %2$s.', 'secupress' ),
+			'<strong>' . __( 'Block SQLi Scan Attempts', 'secupress' ) . '</strong>',
+			'<a target="_blank" href="' . esc_url( secupress_admin_url( 'modules', 'firewall' ) ) . '#row-bbq-url-content_bad-sqli-scan">' . __( 'Firewall', 'secupress' ) . '</a>'
+		);
+
 		$messages = array(
 			// "good"
 			0   => __( 'You are currently blocking <strong>automated scanning</strong>.', 'secupress' ),
 			1   => __( 'Protection activated against <strong>automated scanning</strong>', 'secupress' ),
 			// "warning"
-			100 => __( 'Unable to determine if you are blocking <strong>automated scanning</strong>.', 'secupress' ),
+			100 => __( 'Unable to determine if you are blocking <strong>automated scanning</strong>.', 'secupress' ) . ' ' . $activate_protection_message,
 			// "bad"
 			200 => __( 'Your website should block <strong>automated scanning</strong>.', 'secupress' ),
 		);

--- a/inc/classes/scanners/class-secupress-scan-bad-request-methods.php
+++ b/inc/classes/scanners/class-secupress-scan-bad-request-methods.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Bad_Request_Methods extends SecuPress_Scan implements SecuP
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0.1';
+	const VERSION = '1.0.2';
 
 
 	/** Properties. ============================================================================= */
@@ -58,12 +58,18 @@ class SecuPress_Scan_Bad_Request_Methods extends SecuPress_Scan implements SecuP
 	 * @return (string|array) A message if a message ID is provided. An array containing all messages otherwise.
 	 */
 	public static function get_messages( $message_id = null ) {
+		/** Translators: 1 is the name of a protection, 2 is the name of a module. */
+		$activate_protection_message = sprintf( __( 'But you can activate the %1$s protection from the module %2$s.', 'secupress' ),
+			'<strong>' . __( 'Block Bad Request Methods', 'secupress' ) . '</strong>',
+			'<a target="_blank" href="' . esc_url( secupress_admin_url( 'modules', 'firewall' ) ) . '#row-bbq-headers_request-methods-header">' . __( 'Firewall', 'secupress' ) . '</a>'
+		);
+
 		$messages = array(
 			// "good"
 			0   => __( 'You are currently blocking bad request methods.', 'secupress' ),
 			1   => __( 'Protection activated', 'secupress' ),
 			// "warning"
-			100 => _n_noop( 'Unable to determine the status of your homepage for %s request method.', 'Unable to determine the status of your homepage for %s request methods.', 'secupress' ),
+			100 => _n_noop( 'Unable to determine the status of your homepage for %s request method.', 'Unable to determine the status of your homepage for %s request methods.', 'secupress' ) . ' ' . $activate_protection_message,
 			// "bad"
 			200 => _n_noop( 'Your website should block %s request method.', 'Your website should block %s request methods.', 'secupress' ),
 		);

--- a/inc/classes/scanners/class-secupress-scan-bad-user-agent.php
+++ b/inc/classes/scanners/class-secupress-scan-bad-user-agent.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Bad_User_Agent extends SecuPress_Scan implements SecuPress_
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0.1';
+	const VERSION = '1.0.2';
 
 
 	/** Properties. ============================================================================= */
@@ -58,12 +58,18 @@ class SecuPress_Scan_Bad_User_Agent extends SecuPress_Scan implements SecuPress_
 	 * @return (string|array) A message if a message ID is provided. An array containing all messages otherwise.
 	 */
 	public static function get_messages( $message_id = null ) {
+		/** Translators: 1 is the name of a protection, 2 is the name of a module. */
+		$activate_protection_message = sprintf( __( 'But you can activate the %1$s protection from the module %2$s.', 'secupress' ),
+			'<strong>' . __( 'Block bad User Agents', 'secupress' ) . '</strong>',
+			'<a target="_blank" href="' . esc_url( secupress_admin_url( 'modules', 'firewall' ) ) . '#row-bbq-headers_user-agents-header">' . __( 'Firewall', 'secupress' ) . '</a>'
+		);
+
 		$messages = array(
 			// "good"
 			0   => __( 'You are currently blocking bad User Agents.', 'secupress' ),
 			1   => __( 'Protection activated', 'secupress' ),
 			// "warning"
-			100 => __( 'Unable to determine if your homepage is accessible by bad User Agents.', 'secupress' ),
+			100 => __( 'Unable to determine if your homepage is accessible by bad User Agents.', 'secupress' ) . ' ' . $activate_protection_message,
 			// "bad"
 			200 => __( 'Your website should block <code>HTTP</code> requests for <strong>bad User Agents</strong>.', 'secupress' ),
 		);

--- a/inc/classes/scanners/class-secupress-scan-block-long-url.php
+++ b/inc/classes/scanners/class-secupress-scan-block-long-url.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Block_Long_URL extends SecuPress_Scan implements SecuPress_
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0.1';
+	const VERSION = '1.0.2';
 
 
 	/** Properties. ============================================================================= */
@@ -67,12 +67,18 @@ class SecuPress_Scan_Block_Long_URL extends SecuPress_Scan implements SecuPress_
 	 * @return (string|array) A message if a message ID is provided. An array containing all messages otherwise.
 	 */
 	public static function get_messages( $message_id = null ) {
+		/** Translators: 1 is the name of a protection, 2 is the name of a module. */
+		$activate_protection_message = sprintf( __( 'But you can activate the %1$s protection from the module %2$s.', 'secupress' ),
+			'<strong>' . __( 'Block Long URLs', 'secupress' ) . '</strong>',
+			'<a target="_blank" href="' . esc_url( secupress_admin_url( 'modules', 'firewall' ) ) . '#row-bbq-url-content_bad-url-length">' . __( 'Firewall', 'secupress' ) . '</a>'
+		);
+
 		$messages = array(
 			// "good"
 			0   => __( 'You are currently blocking <strong>excessively long string requests</strong>.', 'secupress' ),
 			1   => __( 'Protection activated', 'secupress' ),
 			// "warning"
-			100 => __( 'Unable to determine if your website is blocking <strong>excessively long string requests</strong>.', 'secupress' ),
+			100 => __( 'Unable to determine if your website is blocking <strong>excessively long string requests</strong>.', 'secupress' ) . ' ' . $activate_protection_message,
 			// "bad"
 			200 => __( 'Your website should block <strong>excessively long string requests</strong>.', 'secupress' ),
 		);

--- a/inc/classes/scanners/class-secupress-scan-directory-listing.php
+++ b/inc/classes/scanners/class-secupress-scan-directory-listing.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Directory_Listing extends SecuPress_Scan implements SecuPre
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0.2';
+	const VERSION = '1.0.3';
 
 
 	/** Properties. ============================================================================= */
@@ -78,10 +78,10 @@ class SecuPress_Scan_Directory_Listing extends SecuPress_Scan implements SecuPre
 			// "good"
 			0   => __( 'Your site does not reveal the files list.', 'secupress' ),
 			/** Translators: %s is a file name. */
-			1   => sprintf( __( 'The rules forbidding access to directory listing have been successfully added to your %s file.', 'secupress' ), "<code>$config_file</code>" ) . ' ' . $activate_protection_message,
+			1   => sprintf( __( 'The rules forbidding access to directory listing have been successfully added to your %s file.', 'secupress' ), "<code>$config_file</code>" ),
 			// "warning"
 			/** Translators: %s is a URL. */
-			100 => sprintf( __( 'Unable to determine the status of %1$s to read the directory listing.', 'secupress' ), '%s' ),
+			100 => sprintf( __( 'Unable to determine the status of %1$s to read the directory listing.', 'secupress' ), '%s' ) . ' ' . $activate_protection_message,
 			// "bad"
 			/** Translators: %s is a URL. */
 			200 => __( '%s (for example) should not be accessible to anyone because of directory listing.', 'secupress' ),

--- a/inc/classes/scanners/class-secupress-scan-discloses.php
+++ b/inc/classes/scanners/class-secupress-scan-discloses.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Discloses extends SecuPress_Scan implements SecuPress_Scan_
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.1';
+	const VERSION = '1.1.1';
 
 
 	/** Properties. ============================================================================= */
@@ -70,11 +70,17 @@ class SecuPress_Scan_Discloses extends SecuPress_Scan implements SecuPress_Scan_
 	public static function get_messages( $message_id = null ) {
 		$module_url = esc_url( secupress_admin_url( 'modules', 'sensitive-data' ) );
 		/** Translators: 1 and 2 are the name of protections, 3 is the name of a module. */
-		$activate_protection_message = sprintf( __( 'But you can activate the %1$s protection and the %2$s protection from the module %3$s.', 'secupress' ),
+		$activate_protections_message = sprintf( __( 'But you can activate the %1$s protection and the %2$s protection from the module %3$s.', 'secupress' ),
 			'<a target="_blank" href="' . $module_url . '#row-content-protect_wp-version">' . __( 'WordPress Version Disclosure', 'secupress' ) . '</a>',
 			'<a target="_blank" href="' . $module_url . '#row-content-protect_php-version">' . __( 'PHP Version Disclosure', 'secupress' ) . '</a>',
 			'<strong>' . __( 'Sensitive Data', 'secupress' ) . '</strong>'
 		);
+		/** Translators: 1 is the name of a protection, 2 is the name of a module. */
+		$activate_protection_message = sprintf( __( 'But you can activate the %1$s protection from the module %2$s.', 'secupress' ),
+			'<strong>' . __( 'WordPress Version Disclosure', 'secupress' ) . '</strong>',
+			'<a target="_blank" href="' . $module_url . '#row-content-protect_wp-version">' . __( 'WordPress Version Disclosure', 'secupress' ) . '</a>'
+		);
+
 
 		$messages   = array(
 			// "good"
@@ -82,9 +88,9 @@ class SecuPress_Scan_Discloses extends SecuPress_Scan implements SecuPress_Scan_
 			1   => __( 'The protection preventing your site to disclose your <strong>PHP version</strong> has been activated.', 'secupress' ),
 			7   => __( 'The protection preventing your site to disclose your <strong>WordPress version</strong> has been activated.', 'secupress' ),
 			// "warning"
-			100 => __( 'Unable to determine if your homepage is disclosing your <strong>WordPress version</strong> or <strong>PHP version</strong>.', 'secupress' ) . ' ' . $activate_protection_message,
+			100 => __( 'Unable to determine if your homepage is disclosing your <strong>WordPress version</strong> or <strong>PHP version</strong>.', 'secupress' ) . ' ' . $activate_protections_message,
 			/** Translators: %s is a file name. */
-			101 => sprintf( __( 'Unable to determine if the %s file is disclosing your <strong>WordPress version</strong>.', 'secupress' ), '<code>readme.html</code>' ),
+			101 => sprintf( __( 'Unable to determine if the %s file is disclosing your <strong>WordPress version</strong>.', 'secupress' ), '<code>readme.html</code>' ) . ' ' . $activate_protection_message,
 			// "bad"
 			200 => __( 'The website displays the <strong>PHP version</strong> in the request headers.', 'secupress' ),
 			201 => __( 'The website displays the <strong>WordPress version</strong> in the homepage source code (%s).', 'secupress' ),

--- a/inc/classes/scanners/class-secupress-scan-shellshock.php
+++ b/inc/classes/scanners/class-secupress-scan-shellshock.php
@@ -20,7 +20,7 @@ class SecuPress_Scan_Shellshock extends SecuPress_Scan implements SecuPress_Scan
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.1';
+	const VERSION = '1.1.1';
 
 
 	/** Properties. ============================================================================= */
@@ -74,7 +74,7 @@ class SecuPress_Scan_Shellshock extends SecuPress_Scan implements SecuPress_Scan
 			// "warning"
 			100 => sprintf( __( 'Unable to determine the status of the <strong>Shellshock</strong> flaw (%s).', 'secupress' ), '<em>CVE-2014-6271</em>' ) . ' ' . $activate_protection_message,
 			101 => sprintf( __( 'Unable to determine the status of the <strong>Shellshock</strong> flaw (%s).', 'secupress' ), '<em>CVE-2014-7169</em>' ) . ' ' . $activate_protection_message,
-			102 => __( 'Unable to determine the status of the <strong>Shellshock</strong> flaw.', 'secupress' ),
+			102 => __( 'Unable to determine the status of the <strong>Shellshock</strong> flaw.', 'secupress' ) . ' ' . $activate_protection_message,
 			// "bad"
 			200 => sprintf( __( 'The server appears to be vulnerable to <strong>Shellshock</strong> (%s).', 'secupress' ), '<em>CVE-2014-6271</em>' ),
 			201 => sprintf( __( 'The server appears to be vulnerable to <strong>Shellshock</strong> (%s).', 'secupress' ), '<em>CVE-2014-7169</em>' ),

--- a/inc/classes/scanners/class-secupress-scan-sqli.php
+++ b/inc/classes/scanners/class-secupress-scan-sqli.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_SQLi extends SecuPress_Scan implements SecuPress_Scan_Inter
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0.1';
+	const VERSION = '1.0.2';
 
 
 	/** Properties. ============================================================================= */
@@ -58,12 +58,18 @@ class SecuPress_Scan_SQLi extends SecuPress_Scan implements SecuPress_Scan_Inter
 	 * @return (string|array) A message if a message ID is provided. An array containing all messages otherwise.
 	 */
 	public static function get_messages( $message_id = null ) {
+		/** Translators: 1 is the name of a protection, 2 is the name of a module. */
+		$activate_protection_message = sprintf( __( 'But you can activate the %1$s protection from the module %2$s.', 'secupress' ),
+			'<strong>' . __( 'block bad content', 'secupress' ) . '</strong>',
+			'<a target="_blank" href="' . esc_url( secupress_admin_url( 'modules', 'firewall' ) ) . '#row-bbq-url-content_bad-contents">' . __( 'Firewall', 'secupress' ) . '</a>'
+		);
+
 		$messages = array(
 			// "good"
 			0   => __( 'You are currently blocking simple SQL Injection.', 'secupress' ),
 			1   => __( 'Protection activated', 'secupress' ),
 			// "warning"
-			100 => __( 'Unable to determine if your homepage is blocking SQL Injection.', 'secupress' ),
+			100 => __( 'Unable to determine if your homepage is blocking SQL Injection.', 'secupress' ) . ' ' . $activate_protection_message,
 			// "bad"
 			200 => __( 'Your website should block <strong>SQL Injection</strong>.', 'secupress' ),
 		);

--- a/inc/classes/scanners/class-secupress-scan-subscription.php
+++ b/inc/classes/scanners/class-secupress-scan-subscription.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Subscription extends SecuPress_Scan implements SecuPress_Sc
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0.1';
+	const VERSION = '1.0.2';
 
 
 	/** Properties. ============================================================================= */
@@ -69,13 +69,19 @@ class SecuPress_Scan_Subscription extends SecuPress_Scan implements SecuPress_Sc
 	 * @return (string|array) A message if a message ID is provided. An array containing all messages otherwise.
 	 */
 	public static function get_messages( $message_id = null ) {
+		/** Translators: 1 is the name of a protection, 2 is the name of a module. */
+		$activate_protection_message = sprintf( __( 'But you can activate the %1$s protection from the module %2$s.', 'secupress' ),
+			'<strong>' . __( 'Use a Captcha for everyone', 'secupress' ) . '</strong>',
+			'<a target="_blank" href="' . esc_url( secupress_admin_url( 'modules', 'users-login' ) ) . '#row-captcha_activate">' . __( 'Users & Login', 'secupress' ) . '</a>'
+		);
+
 		$messages = array(
 			// "good"
 			0   => __( 'Your subscription settings are set correctly.', 'secupress' ),
 			1   => __( 'A captcha module has been activated to block bot registration.', 'secupress' ),
 			2   => __( 'The user role for new registrations has been set to <strong>Subscriber</strong>.', 'secupress' ),
 			// "warning"
-			100 => __( 'Unable to determine the status of your subscribtion settings.', 'secupress' ),
+			100 => __( 'Unable to determine the status of your subscription settings.', 'secupress' ) . ' ' . $activate_protection_message,
 			/** Translators: %s is the plugin name. */
 			101 => sprintf( __( 'You have a big network, %s must work on some data before being able to perform this scan.', 'secupress' ), '<strong>' . SECUPRESS_PLUGIN_NAME . '</strong>' ),
 			// "bad"


### PR DESCRIPTION
For some "100" scanner messages, added missing links to the sub-module the fixes activate.