### PR TITLE
Fixes SEC-352: Auto Update constants

### DIFF
--- a/inc/classes/scanners/class-secupress-scan-auto-update.php
+++ b/inc/classes/scanners/class-secupress-scan-auto-update.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Auto_Update extends SecuPress_Scan implements SecuPress_Sca
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0';
+	const VERSION = '1.1';
 
 
 	/** Properties. ============================================================================= */
@@ -64,6 +64,40 @@ class SecuPress_Scan_Auto_Update extends SecuPress_Scan implements SecuPress_Sca
 			1   => __( 'Protection activated', 'secupress' ),
 			// "bad"
 			200 => __( 'Your installation <strong>cannot auto-update</strong> itself.', 'secupress' ),
+			207 => _n_noop(
+				/** Translators: 1 is a value, 2 is a PHP constant name (or a list of names). */
+				'The following constant should not be set to %1$s: %2$s.',
+				'The following constants should not be set to %1$s: %2$s.',
+				'secupress'
+			),
+			208 => _n_noop(
+				/** Translators: 1 is a value, 2 is a PHP constant name (or a list of names). */
+				'The following constant should not be set to %1$s: %2$s.',
+				'The following constants should not be set to %1$s: %2$s.',
+				'secupress'
+			),
+			209 => _n_noop(
+				/** Translators: 1 is a value, 2 is a filter name (or a list of names). */
+				'The following filter should not be used or set to return %1$s: %2$s.',
+				'The following filters should not be used or set to return %1$s: %2$s.',
+				'secupress'
+			),
+			210 => _n_noop(
+				/** Translators: 1 is a value, 2 is a filter name (or a list of names). */
+				'The following filter should not be used or set to return %1$s: %2$s.',
+				'The following filters should not be used or set to return %1$s: %2$s.',
+				'secupress'
+			),
+			// "cantfix"
+			/** Translators: 1 is a file name, 2 is some code. */
+			300 => sprintf( __( 'The %1$s file is not writable. Please remove the following code from the file: %2$s', 'secupress' ), '<code>wp-config.php</code>', '%s' ),
+			301 => _n_noop(
+				/** Translators: 1 is the plugin name, 2 is a file name, 3 is some code. */
+				'%1$s could not remove a constant definition from the %2$s file. Please remove the following line from the file: %3$s',
+				'%1$s could not remove some constant definitions from the %2$s file. Please remove the following lines from the file: %3$s',
+				'secupress'
+			),
+			// DEPRECATED, NOT IN USE ANYMORE.
 			201 => __( '<code>DISALLOW_FILE_MODS</code> should be set to <code>FALSE</code>.', 'secupress' ),
 			202 => __( '<code>AUTOMATIC_UPDATER_DISABLED</code> should be set to <code>FALSE</code>.', 'secupress' ),
 			203 => __( '<code>DISALLOW_FILE_MODS</code> and <code>AUTOMATIC_UPDATER_DISABLED</code> should be set to <code>FALSE</code>.', 'secupress' ),
@@ -90,36 +124,56 @@ class SecuPress_Scan_Auto_Update extends SecuPress_Scan implements SecuPress_Sca
 	 * @return (array) The scan results.
 	 */
 	public function scan() {
-		// "bad"
-		$constants = 0;
-		$filters   = 0;
+		$constants_false = array();
+		$constants_true  = array();
+		$constants       = array(
+			'DISALLOW_FILE_MODS'         => true,
+			'AUTOMATIC_UPDATER_DISABLED' => true,
+			'WP_AUTO_UPDATE_CORE'        => false,
+		);
 
-		if ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) {
-			$constants += 1;
+		foreach ( $constants as $constant => $val ) {
+			if ( defined( $constant ) && (bool) constant( $constant ) === $val ) {
+				if ( $val ) {
+					$constants_true[] = "<code>$constant</code>";
+				} else {
+					$constants_false[] = "<code>$constant</code>";
+				}
+			}
 		}
 
-		if ( defined( 'AUTOMATIC_UPDATER_DISABLED' ) && AUTOMATIC_UPDATER_DISABLED ) {
-			$constants += 2;
+		$filters_false = array();
+		$filters_true  = array();
+		$filters       = array(
+			'automatic_updater_disabled'    => true,
+			'allow_minor_auto_core_updates' => false,
+		);
+
+		foreach ( $filters as $filter => $val ) {
+			/** This filter is documented wp-admin/includes/class-wp-upgrader.php */
+			if ( apply_filters( $filter, ! $val ) === $val ) {
+				if ( $val ) {
+					$filters_true[] = "<code>$filter</code>";
+				} else {
+					$filters_false[] = "<code>$filter</code>";
+				}
+			}
 		}
 
-		/** This filter is documented wp-admin/includes/class-wp-upgrader.php */
-		if ( true === apply_filters( 'automatic_updater_disabled', false ) ) {
-			$filters += 1;
-		}
-
-		/** This filter is documented wp-admin/includes/class-wp-upgrader.php */
-		if ( false === apply_filters( 'allow_minor_auto_core_updates', true ) ) {
-			$filters += 2;
-		}
-
-		if ( $constants || $filters ) {
+		if ( $constants_false || $constants_true || $filters_false || $filters_true ) {
 			$this->add_message( 200 );
 
-			if ( $constants ) {
-				$this->add_message( 200 + $constants );
+			if ( $constants_false ) {
+				$this->add_message( 207, array( count( $constants_false ), '<code>false</code>', $constants_false ) );
 			}
-			if ( $filters ) {
-				$this->add_message( 203 + $filters );
+			if ( $constants_true ) {
+				$this->add_message( 208, array( count( $constants_true ), '<code>true</code>', $constants_true ) );
+			}
+			if ( $filters_false ) {
+				$this->add_message( 209, array( count( $filters_false ), '<code>false</code>', $filters_false ) );
+			}
+			if ( $filters_true ) {
+				$this->add_message( 210, array( count( $filters_true ), '<code>true</code>', $filters_true ) );
 			}
 		} else {
 			$this->add_message( 0 );
@@ -142,21 +196,32 @@ class SecuPress_Scan_Auto_Update extends SecuPress_Scan implements SecuPress_Sca
 	 * @return (array) The fix results.
 	 */
 	public function fix() {
+		global $wp_settings_errors;
+
 		secupress_activate_submodule( 'wordpress-core', 'minor-updates' );
 
-		$wpconfig_filepath = secupress_is_wpconfig_writable();
-		$constants         = array( 'AUTOMATIC_UPDATER_DISABLED' => true, 'WP_AUTO_UPDATE_CORE' => false );
+		// Get the error.
+		$last_error = is_array( $wp_settings_errors ) && $wp_settings_errors ? end( $wp_settings_errors ) : false;
 
-		if ( $wpconfig_filepath ) {
-			foreach ( $constants as $constant => $val ) {
-				if ( defined( $constant ) && (bool) constant( $constant ) === $val ) {
-					$val = $val ? 'false' : 'true';
-					secupress_comment_constant( $constant, $wpconfig_filepath, false, $val );
-				}
+		if ( $last_error && 'general' === $last_error['setting'] ) {
+			if ( 'wp_config_not_writable' === $last_error['code'] ) {
+
+				$rules = static::get_rules_from_error( $last_error );
+				// "cantfix"
+				$this->add_fix_message( 300, array( $rules ) );
+				array_pop( $wp_settings_errors );
+
+			} elseif ( 'constant_not_commented' === $last_error['code'] ) {
+
+				$rules = static::get_rules_from_error( $last_error );
+				$count = substr_count( $rules, "\n" ) + 1;
+				// "cantfix"
+				$this->add_fix_message( 301, array( $count, SECUPRESS_PLUGIN_NAME, '<code>wp-config.php</code>', $rules ) );
+				array_pop( $wp_settings_errors );
 			}
 		}
 
-		$this->add_fix_message( 1 );
+		$this->maybe_set_fix_status( 1 );
 
 		return parent::fix();
 	}

--- a/inc/modules/wordpress-core/plugins/minor-updates.php
+++ b/inc/modules/wordpress-core/plugins/minor-updates.php
@@ -1,13 +1,110 @@
 <?php
-/*
-Module Name: Minor Updates
-Description: Allow Auto Updates for Minor Versions
-Main Module: wordpress_core
-Author: SecuPress
-Version: 1.0
-*/
+/**
+ * Module Name: Minor Updates
+ * Description: Allow Auto Updates for Minor Versions
+ * Main Module: wordpress_core
+ * Author: SecuPress
+ * Version: 1.1
+ */
+
 defined( 'SECUPRESS_VERSION' ) or die( 'Cheatin&#8217; uh?' );
 
-// Fix using filters automatic_updater_disabled, automatic_updater_disabled.
+/** --------------------------------------------------------------------------------------------- */
+/** ACTIVATION / DEACTIVATION =================================================================== */
+/** --------------------------------------------------------------------------------------------- */
+
+add_action( 'secupress.modules.activate_submodule_' . basename( __FILE__, '.php' ), 'secupress_minor_updates_activation' );
+add_action( 'secupress.plugins.activation', 'secupress_minor_updates_activation' );
+/**
+ * On module activation, comment the defines.
+ *
+ * @since 1.2.3
+ * @author Grégory Viguier
+ */
+function secupress_minor_updates_activation() {
+	// Comment the 2 constants if they are defined.
+	$filepath  = secupress_is_wpconfig_writable();
+	$failed    = array();
+	$constants = array(
+		'DISALLOW_FILE_MODS'         => true,
+		'AUTOMATIC_UPDATER_DISABLED' => true,
+		'WP_AUTO_UPDATE_CORE'        => false,
+	);
+
+	foreach ( $constants as $constant => $val ) {
+		if ( ! defined( $constant ) || (bool) constant( $constant ) !== $val ) {
+			continue;
+		}
+
+		if ( $filepath ) {
+			$success = secupress_comment_constant( $constant, $filepath );
+		} else {
+			$success = false;
+		}
+
+		if ( ! $success ) {
+			$val      = $val ? 'true' : 'false';
+			$failed[] = "define( '$constant', $val );";
+		}
+	}
+
+	if ( ! $failed ) {
+		// OK: not defined or successfully commented.
+		return;
+	}
+
+	$count  = count( $failed );
+	$failed = implode( "\n", $failed );
+
+	if ( ! $filepath ) {
+		$message = sprintf(
+			/** Translators: 1 is a file name, 2 is some code. */
+			__( 'The %1$s file is not writable. Please remove the following code from the file: %2$s', 'secupress' ),
+			'<code>wp-config.php</code>',
+			"<pre>$failed</pre>"
+		);
+		add_settings_error( 'general', 'wp_config_not_writable', $message, 'error' );
+	} else {
+		$message = sprintf(
+			/** Translators: 1 is the plugin name, 2 is a file name, 3 is some code. */
+			_n( '%1$s couldn\'t remove a constant definition from the %2$s file. Please remove the following line from the file: %3$s', '%1$s couldn\'t remove some constant definitions from the %2$s file. Please remove the following lines from the file: %3$s', $count, 'secupress' ),
+			SECUPRESS_PLUGIN_NAME,
+			'<code>wp-config.php</code>',
+			"<pre>$failed</pre>"
+		);
+		add_settings_error( 'general', 'constant_not_commented', $message, 'error' );
+	}
+}
+
+
+add_action( 'secupress.modules.deactivate_submodule_' . basename( __FILE__, '.php' ), 'secupress_minor_updates_deactivate' );
+add_action( 'secupress.plugins.deactivation', 'secupress_minor_updates_deactivate' );
+/**
+ * On module deactivation, maybe put the constants back.
+ *
+ * @since 1.2.3
+ * @author Grégory Viguier
+ */
+function secupress_minor_updates_deactivate() {
+	// Unomment the 2 constants.
+	$filepath  = secupress_is_wpconfig_writable();
+	$constants = array(
+		'DISALLOW_FILE_MODS',
+		'AUTOMATIC_UPDATER_DISABLED',
+		'WP_AUTO_UPDATE_CORE',
+	);
+
+	if ( $filepath ) {
+		foreach ( $constants as $constant ) {
+			secupress_uncomment_constant( $constant, $filepath );
+		}
+	}
+}
+
+
+/** --------------------------------------------------------------------------------------------- */
+/** USE FILTERS ================================================================================= */
+/** --------------------------------------------------------------------------------------------- */
+
 add_filter( 'automatic_updater_disabled',    '__return_false', PHP_INT_MAX );
 add_filter( 'allow_minor_auto_core_updates', '__return_true',  PHP_INT_MAX );


### PR DESCRIPTION
Auto Update for minor versions:
- Revamp the scanner. Test for the constant `WP_AUTO_UPDATE_CORE` was missing. The fix doesn't write the `wp-config.php` file by itself, it is done during the sub-module activation. Errors during the fix are handled.
- Sub-module: write the `wp-config.php` file during (de)activation to (un)comment the constant definitions. `DISALLOW_FILE_MODS` has been added (it was not included in the original fix). Errors if the constants can't be commented are handled.