### PR TITLE
Fixes SEC-329: Directory listing with blank page and status 200

### DIFF
--- a/inc/classes/scanners/class-secupress-scan-directory-listing.php
+++ b/inc/classes/scanners/class-secupress-scan-directory-listing.php
@@ -17,7 +17,7 @@ class SecuPress_Scan_Directory_Listing extends SecuPress_Scan implements SecuPre
 	 *
 	 * @var (string)
 	 */
-	const VERSION = '1.0.2';
+	const VERSION = '1.0.3';
 
 
 	/** Properties. ============================================================================= */
@@ -120,11 +120,15 @@ class SecuPress_Scan_Directory_Listing extends SecuPress_Scan implements SecuPre
 		if ( ! is_wp_error( $response ) ) {
 
 			if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
-				// "bad"
-				$this->add_message( 200, array( '<code>' . $base_url . '</code>' ) );
+				$body = trim( wp_remote_retrieve_body( $response ) );
 
-				if ( ! $this->fixable ) {
-					$this->add_pre_fix_message( 301 );
+				if ( strlen( $body ) > 25 ) {
+					// "bad"
+					$this->add_message( 200, array( '<code>' . $base_url . '</code>' ) );
+
+					if ( ! $this->fixable ) {
+						$this->add_pre_fix_message( 301 );
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Directory Listing scan now works properly if the scan response has a http code 200 with a "Silence is golden" message.