### PR TITLE
Fixes SEC-357: too long URLs, allow internal requests via a nonce

### DIFF
--- a/inc/modules/firewall/plugins/bad-url-length.php
+++ b/inc/modules/firewall/plugins/bad-url-length.php
@@ -4,37 +4,100 @@
  * Description: Block requests containing more than 300 (default) chars in URL.
  * Main Module: firewall
  * Author: SecuPress
- * Version: 1.0
+ * Version: 1.1
  */
+
 defined( 'SECUPRESS_VERSION' ) or die( 'Cheatin&#8217; uh?' );
 
-$parse_url = explode( '?', $_SERVER['REQUEST_URI'] );
-$parse_url = parse_str( end( $parse_url ), $args );
+define( 'SECUPRESS_BBUL_HEADER_NAME', 'X-SECUPRESS-BBUL-NONCE' );
 
-unset( $args['_wp_http_referer'] );
 
 /**
- * Filter the request uri arguments.
+ * Block the current request if the requested URL is too long.
  *
- * @since 1.0
- *
- * @param (array) $args The request uri arguments.
+ * @since 1.2.3
+ * @author Julio Potier
  */
-$args = apply_filters( 'secupress.plugin.bad-url-length.args', $args );
+function secupress_block_too_long_url() {
+	$parse_url = explode( '?', $_SERVER['REQUEST_URI'] );
+	parse_str( end( $parse_url ), $args );
 
-/**
- * Filter the maximum uri length.
- *
- * @since 1.0
- *
- * @param (int) $length The maximum length. Default is 300.
- */
-$length = apply_filters( 'secupress.plugin.bad-url-length.len', 300 );
+	unset( $args['_wp_http_referer'] );
 
-$url_test = http_build_query( $args );
+	/**
+	 * Filter the request uri arguments.
+	 *
+	 * @since 1.0
+	 *
+	 * @param (array) $args The request uri arguments.
+	 */
+	$args = apply_filters( 'secupress.plugin.bad-url-length.args', $args );
 
-if ( strlen( $url_test ) > $length ) {
+	/**
+	 * Filter the maximum uri length.
+	 *
+	 * @since 1.0
+	 *
+	 * @param (int) $length The maximum length. Default is 300.
+	 */
+	$length = apply_filters( 'secupress.plugin.bad-url-length.len', 300 );
+
+	$url_test = http_build_query( $args );
+
+	if ( strlen( $url_test ) <= $length ) {
+		// The URL is not too long.
+		return;
+	}
+
+	if ( ! secupress_is_scan_request() ) {
+		// Search for our nonce.
+		$header_name = 'HTTP_' . str_replace( '-', '_', SECUPRESS_BBUL_HEADER_NAME );
+
+		foreach ( $_SERVER as $key => $val ) {
+			if ( strtoupper( $key ) === $header_name ) {
+				// We found our header.
+				if ( wp_verify_nonce( $val, 'secupress_block_too_long_url' ) ) {
+					// The nonce is fine, bail out.
+					return;
+				}
+				// The nonce is not OK. No need to continue our loop.
+				break;
+			}
+		}
+	}
+
+	// Block.
 	secupress_block( 'BUL', 414 );
 }
 
-unset( $url_test, $args, $parse_url, $length );
+secupress_block_too_long_url();
+
+
+add_filter( 'http_request_args', 'secupress_bbul_add_nonce_header', 10, 2 );
+/**
+ * For a local request, add a nonce in a header.
+ *
+ * @since 1.2.3
+ * @author Grégory Viguier
+ *
+ * @param (array)  $r   The request parameters.
+ * @param (string) $url The request URL.
+ *
+ * @return (array)
+ */
+function secupress_bbul_add_nonce_header( $r, $url ) {
+	static $local_url;
+
+	if ( ! isset( $local_url ) ) {
+		$local_url = trailingslashit( set_url_scheme( home_url() ) );
+	}
+
+	$url = trailingslashit( set_url_scheme( $url ) );
+
+	if ( strpos( $url, $local_url ) === 0 ) {
+		// It's a local request.
+		$r['headers'][ SECUPRESS_BBUL_HEADER_NAME ] = wp_create_nonce( 'secupress_block_too_long_url' );
+	}
+
+	return $r;
+}

--- a/inc/modules/firewall/plugins/bad-url-length.php
+++ b/inc/modules/firewall/plugins/bad-url-length.php
@@ -44,7 +44,7 @@ function secupress_block_too_long_url() {
 
 	$url_test = http_build_query( $args );
 
-	if ( strlen( $url_test ) <= $length ) {
+	if ( mb_strlen( $url_test ) <= $length ) {
 		// The URL is not too long.
 		return;
 	}
@@ -54,15 +54,17 @@ function secupress_block_too_long_url() {
 		$header_name = 'HTTP_' . str_replace( '-', '_', SECUPRESS_BBUL_HEADER_NAME );
 
 		foreach ( $_SERVER as $key => $val ) {
-			if ( strtoupper( $key ) === $header_name ) {
-				// We found our header.
-				if ( wp_verify_nonce( $val, 'secupress_block_too_long_url' ) ) {
-					// The nonce is fine, bail out.
-					return;
-				}
-				// The nonce is not OK. No need to continue our loop.
-				break;
+			if ( strtoupper( $key ) !== $header_name ) {
+				// Not the header we want.
+				continue;
 			}
+			// We found our header.
+			if ( wp_verify_nonce( $val, 'secupress_block_too_long_url' ) ) {
+				// The nonce is fine, bail out.
+				return;
+			}
+			// The nonce is not OK (and no need to continue our loop).
+			break;
 		}
 	}
 


### PR DESCRIPTION
Allow local requests (to self) to bypass the "Too Long URL" protection by providing a nonce in a header. This nonce is provided by filtering `wp_remote_***()` args.