### PR TITLE
Fixes SEC-371: no menu icon in WP 3.7

### DIFF
--- a/inc/admin/multisite/settings.php
+++ b/inc/admin/multisite/settings.php
@@ -123,7 +123,6 @@ function secupress_create_subsite_menu() {
 
 	$site_id = get_current_blog_id();
 	$sites   = secupress_get_results_for_ms_scanner_fixes();
-	$cap     = secupress_get_capability( true );
 	$menu    = false;
 
 	if ( ! $sites ) {
@@ -141,8 +140,11 @@ function secupress_create_subsite_menu() {
 		return;
 	}
 
+	$cap  = secupress_get_capability( true );
+	$icon = secupress_wp_version_is( '3.8' ) ? 'dashicons-shield-alt' : '';
+
 	// Menu item.
-	add_menu_page( SECUPRESS_PLUGIN_NAME, 'secupress', $cap, SECUPRESS_PLUGIN_SLUG . '_scanners', 'secupress_subsite_scanners', 'dashicons-shield-alt' );
+	add_menu_page( SECUPRESS_PLUGIN_NAME, 'secupress', $cap, SECUPRESS_PLUGIN_SLUG . '_scanners', 'secupress_subsite_scanners', $icon );
 
 	// Display a notice for Administrators.
 	if ( 'admin.php' !== $pagenow || empty( $_GET['page'] ) || SECUPRESS_PLUGIN_SLUG . '_scanners' !== $_GET['page'] ) {

--- a/inc/admin/settings.php
+++ b/inc/admin/settings.php
@@ -290,9 +290,10 @@ function secupress_create_menus() {
 	// Add a counter of scans with bad result.
 	$count = sprintf( ' <span class="update-plugins count-%1$d"><span class="update-count">%1$d</span></span>', secupress_get_scanner_counts( 'bad' ) );
 	$cap   = secupress_get_capability();
+	$icon  = secupress_wp_version_is( '3.8' ) ? 'dashicons-shield-alt' : '';
 
 	// Main menu item.
-	add_menu_page( SECUPRESS_PLUGIN_NAME, 'secupress', $cap, SECUPRESS_PLUGIN_SLUG . '_scanners', 'secupress_scanners', 'dashicons-shield-alt' );
+	add_menu_page( SECUPRESS_PLUGIN_NAME, 'secupress', $cap, SECUPRESS_PLUGIN_SLUG . '_scanners', 'secupress_scanners', $icon );
 
 	// Sub-menus.
 	add_submenu_page( SECUPRESS_PLUGIN_SLUG . '_scanners', __( 'Scanners', 'secupress' ), __( 'Scanners', 'secupress' ) . $count, $cap, SECUPRESS_PLUGIN_SLUG . '_scanners', 'secupress_scanners' );


### PR DESCRIPTION
Dashicons arrived in WP 3.8. For lower, at least provide the default "gear" icon.