### PR TITLE
Fixes SEC-170: Notice "can't write .htaccess" is showing while the file does not exist

### DIFF
--- a/inc/admin/notices.php
+++ b/inc/admin/notices.php
@@ -210,20 +210,14 @@ function secupress_warning_htaccess_permissions() {
 	}
 
 	if ( $is_apache ) {
-		$file          = '.htaccess';
-		$htaccess_file = secupress_get_home_path() . $file;
-
-		if ( wp_is_writable( $htaccess_file ) ) {
-			return;
-		}
+		$file = '.htaccess';
 	} elseif ( $is_iis7 ) {
-		$file            = 'web.config';
-		$web_config_file = secupress_get_home_path() . $file;
-
-		if ( wp_is_writable( $web_config_file ) ) {
-			return;
-		}
+		$file = 'web.config';
 	} else {
+		return;
+	}
+
+	if ( secupress_root_file_is_writable( $file ) ) {
 		return;
 	}
 


### PR DESCRIPTION
If the `.htaccess` file doesn't exist but the directory is writable, don't display the notice.