### PR TITLE
Fixes SEC-397: plugins and themes protections and white-listed IPs

### DIFF
--- a/inc/modules/plugins-themes/plugins/plugin-installation.php
+++ b/inc/modules/plugins-themes/plugins/plugin-installation.php
@@ -4,7 +4,7 @@
  * Description: Disabled the plugin installation from repository
  * Main Module: plugins_themes
  * Author: SecuPress
- * Version: 1.0
+ * Version: 1.1
  */
 
 defined( 'SECUPRESS_VERSION' ) or die( 'Cheatin&#8217; uh?' );
@@ -30,7 +30,7 @@ if ( is_admin() ) {
 	 */
 	function secupress_no_plugin_install_page_redirect() {
 		if ( ! isset( $_GET['tab'] ) || 'plugin-information' !== $_GET['tab'] ) {
-			secupress_die( __( 'You do not have sufficient permissions to install plugins on this site.' ) );
+			secupress_die( __( 'You do not have sufficient permissions to install plugins on this site.', 'secupress' ), '', array( 'force_die' => true ) );
 		}
 	}
 
@@ -45,7 +45,7 @@ if ( is_admin() ) {
 	 */
 	function secupress_avoid_install_plugin( $action ) {
 		if ( 'plugin-upload' === $action || strpos( $action, 'install-plugin_' ) === 0 ) {
-			secupress_die( __( 'You do not have sufficient permissions to install plugins on this site.' ) );
+			secupress_die( __( 'You do not have sufficient permissions to install plugins on this site.', 'secupress' ), '', array( 'force_die' => true ) );
 		}
 	}
 
@@ -63,5 +63,5 @@ if ( is_admin() ) {
 }
 
 if ( isset( $_FILES['pluginzip'] ) ) {
-	secupress_die( __( 'You do not have sufficient permissions to install plugins on this site.' ) );
+	secupress_die( __( 'You do not have sufficient permissions to install plugins on this site.', 'secupress' ), '', array( 'force_die' => true ) );
 }

--- a/inc/modules/plugins-themes/plugins/theme-installation.php
+++ b/inc/modules/plugins-themes/plugins/theme-installation.php
@@ -4,7 +4,7 @@
  * Description: Disabled the theme installation from repository
  * Main Module: plugins_themes
  * Author: SecuPress
- * Version: 1.0
+ * Version: 1.1
  */
 
 defined( 'SECUPRESS_VERSION' ) or die( 'Cheatin&#8217; uh?' );
@@ -29,7 +29,7 @@ if ( is_admin() ) {
 	 * @since 1.0
 	 */
 	function secupress_no_theme_install_page() {
-		secupress_die( __( 'You do not have sufficient permissions to install themes on this site.' ) );
+		secupress_die( __( 'You do not have sufficient permissions to install themes on this site.', 'secupress' ), '', array( 'force_die' => true ) );
 	}
 
 
@@ -43,11 +43,11 @@ if ( is_admin() ) {
 	 */
 	function secupress_avoid_switch_theme( $action ) {
 		if ( 'theme-upload' === $action || strpos( $action, 'install-theme_' ) === 0 ) {
-			secupress_die( __( 'You do not have sufficient permissions to install themes on this site.' ) );
+			secupress_die( __( 'You do not have sufficient permissions to install themes on this site.', 'secupress' ), '', array( 'force_die' => true ) );
 		}
 	}
 }
 
 if ( isset( $_FILES['themezip'] ) ) {
-	secupress_die( __( 'You do not have sufficient permissions to install themes on this site.' ) );
+	secupress_die( __( 'You do not have sufficient permissions to install themes on this site.', 'secupress' ), '', array( 'force_die' => true ) );
 }

--- a/inc/modules/plugins-themes/plugins/uploads.php
+++ b/inc/modules/plugins-themes/plugins/uploads.php
@@ -4,15 +4,15 @@
  * Description: Disabled plugins and themes upload.
  * Main Module: uploads
  * Author: SecuPress
- * Version: 1.0
+ * Version: 1.1
  */
 
 defined( 'SECUPRESS_VERSION' ) or die( 'Cheatin&#8217; uh?' );
 
 if ( isset( $_FILES['pluginzip'] ) ) {
-	secupress_die( __( 'You do not have sufficient permissions to install plugins on this site.' ) );
+	secupress_die( __( 'You do not have sufficient permissions to install plugins on this site.', 'secupress' ), '', array( 'force_die' => true ) );
 }
 
 if ( isset( $_FILES['themezip'] ) ) {
-	secupress_die( __( 'You do not have sufficient permissions to install themes on this site.' ) );
+	secupress_die( __( 'You do not have sufficient permissions to install themes on this site.', 'secupress' ), '', array( 'force_die' => true ) );
 }


### PR DESCRIPTION
Plugins and themes: even users with a white-listed IP can't upload or install plugins and themes. Also added our i18n text domain: those strings are not translated by WP.