### PR TITLE
Fixes SEC-111: "block bad user agents" is blocking Cron

### DIFF
--- a/inc/functions/ip.php
+++ b/inc/functions/ip.php
@@ -90,6 +90,7 @@ function secupress_ip_is_whitelisted( $ip = null ) {
 	$whitelist = array(
 		$_SERVER['SERVER_ADDR'] => 1,
 		'::1'                   => 1,
+		'0.0.0.0'               => 1,
 		'127.0.0.1'             => 1,
 		'37.187.85.82'          => 1, // WPRocketbot.
 		'37.187.58.236'         => 1, // WPRocketbot.


### PR DESCRIPTION
Added the IP address `0.0.0.0` to the hardcoded white-list. It should prevent some cron processes to be blocked (because of an empty User Agent for example).