### PR TITLE
Fixes SEC-392: white label slug on license reactivation

### DIFF
--- a/inc/admin/ajax-post-callbacks.php
+++ b/inc/admin/ajax-post-callbacks.php
@@ -570,8 +570,6 @@ function secupress_global_settings_api_key_ajax_post_cb() {
 	// Finally, save.
 	secupress_update_options( $values );
 
-	$new_is_pro = ! empty( $values['site_is_pro'] ) ? 1 : 0;
-
 	// White Label: trick the referrer for the redirection.
 	if ( ! empty( $values['wl_plugin_name'] ) ) {
 		if ( empty( $values['site_is_pro'] ) ) {

--- a/inc/admin/ajax-post-callbacks.php
+++ b/inc/admin/ajax-post-callbacks.php
@@ -570,11 +570,20 @@ function secupress_global_settings_api_key_ajax_post_cb() {
 	// Finally, save.
 	secupress_update_options( $values );
 
+	$new_is_pro = ! empty( $values['site_is_pro'] ) ? 1 : 0;
+
 	// White Label: trick the referrer for the redirection.
-	if ( empty( $values['site_is_pro'] ) && ! empty( $values['wl_plugin_name'] ) ) {
-		$old_slug = ! empty( $old_values['wl_plugin_name'] ) ? sanitize_title( $old_values['wl_plugin_name'] ) : 'secupress';
-		$old_slug = 'page=' . $old_slug . '_settings';
-		$new_slug = 'page=secupress_settings';
+	if ( ! empty( $values['wl_plugin_name'] ) ) {
+		if ( empty( $values['site_is_pro'] ) ) {
+			// Pro deactivation.
+			$old_slug = ! empty( $old_values['wl_plugin_name'] ) ? sanitize_title( $old_values['wl_plugin_name'] ) : 'secupress';
+			$old_slug = 'page=' . $old_slug . '_settings';
+			$new_slug = 'page=secupress_settings';
+		} else {
+			// Pro activation.
+			$old_slug = 'page=secupress_settings';
+			$new_slug = 'page=' . sanitize_title( $values['wl_plugin_name'] ) . '_settings';
+		}
 
 		if ( $old_slug !== $new_slug ) {
 			$_REQUEST['_wp_http_referer'] = str_replace( $old_slug, $new_slug, wp_get_raw_referer() );


### PR DESCRIPTION
On license reactivation, use the white label to change the new page URL. It will prevent to display an error message after redirection.