### PR TITLE
Fixes SEC-402: readme.html's URL should use site URL, not home URL

### DIFF
--- a/inc/classes/scanners/class-secupress-scan-discloses.php
+++ b/inc/classes/scanners/class-secupress-scan-discloses.php
@@ -203,7 +203,7 @@ class SecuPress_Scan_Discloses extends SecuPress_Scan implements SecuPress_Scan_
 		}
 
 		// Readme file. =====================================.
-		$response = wp_remote_get( home_url( 'readme.html' ), $this->get_default_request_args() );
+		$response = wp_remote_get( site_url( 'readme.html' ), $this->get_default_request_args() );
 
 		if ( ! is_wp_error( $response ) ) {
 			if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
@@ -288,7 +288,7 @@ class SecuPress_Scan_Discloses extends SecuPress_Scan implements SecuPress_Scan_
 
 		// Readme file. =====================================.
 		if ( empty( $todo['wp_version'] ) ) {
-			$response = wp_remote_get( home_url( 'readme.html' ), $this->get_default_request_args() );
+			$response = wp_remote_get( site_url( 'readme.html' ), $this->get_default_request_args() );
 
 			if ( ! is_wp_error( $response ) ) {
 				if ( 200 === wp_remote_retrieve_response_code( $response ) ) {

--- a/inc/modules/discloses/plugins/readmes.php
+++ b/inc/modules/discloses/plugins/readmes.php
@@ -98,7 +98,7 @@ function secupress_protect_readmes_plugin_activate( $rules ) {
 function secupress_protect_readmes_apache_rules() {
 	$bases   = secupress_get_rewrite_bases();
 	$base    = $bases['base'];
-	$pattern = '(/|^)(readme|changelog)\.(txt|md|html)$';
+	$pattern = '^' . $bases['site_from'] . '(.*/)?(readme|changelog)\.(txt|md|html)$';
 
 	$rules  = "<IfModule mod_rewrite.c>\n";
 	$rules .= "    RewriteEngine On\n";
@@ -121,7 +121,7 @@ function secupress_protect_readmes_iis7_rules() {
 	$marker  = 'readme_discloses';
 	$spaces  = str_repeat( ' ', 8 );
 	$bases   = secupress_get_rewrite_bases();
-	$pattern = '^' . $bases['home_from'] . '(.*/)?(readme|changelog)\.(txt|md|html)$';
+	$pattern = '^' . $bases['site_from'] . '(.*/)?(readme|changelog)\.(txt|md|html)$';
 
 	$rules  = "<rule name=\"SecuPress $marker\" stopProcessing=\"true\">\n";
 	$rules .= "$spaces  <match url=\"$pattern\"/ ignoreCase=\"true\">\n";
@@ -142,7 +142,7 @@ function secupress_protect_readmes_iis7_rules() {
 function secupress_protect_readmes_nginx_rules() {
 	$marker  = 'readme_discloses';
 	$bases   = secupress_get_rewrite_bases();
-	$pattern = '^' . $bases['home_from'] . '(.+/)?(readme|changelog)\.(txt|md|html)$';
+	$pattern = '^' . $bases['site_from'] . '(.+/)?(readme|changelog)\.(txt|md|html)$';
 
 	// - http://nginx.org/en/docs/http/ngx_http_core_module.html#location
 	$rules  = "

--- a/inc/modules/discloses/plugins/wp-version.php
+++ b/inc/modules/discloses/plugins/wp-version.php
@@ -99,7 +99,7 @@ function secupress_wp_version_plugin_activate( $rules ) {
 function secupress_wp_version_apache_rules() {
 	$bases   = secupress_get_rewrite_bases();
 	$base    = $bases['base'];
-	$pattern = '^' . $bases['site_dir'] . 'readme\.html$';
+	$pattern = '^' . $bases['site_from'] . 'readme\.html$';
 
 	$rules  = "<IfModule mod_rewrite.c>\n";
 	$rules .= "    RewriteEngine On\n";
@@ -122,7 +122,7 @@ function secupress_wp_version_iis7_rules() {
 	$marker  = 'wp_version';
 	$spaces  = str_repeat( ' ', 8 );
 	$bases   = secupress_get_rewrite_bases();
-	$pattern = '^' . $bases['site_dir'] . 'readme\.html$';
+	$pattern = '^' . $bases['site_from'] . 'readme\.html$';
 
 	$rules  = "<rule name=\"SecuPress $marker\" stopProcessing=\"true\">\n";
 	$rules .= "$spaces  <match url=\"$pattern\"/ ignoreCase=\"true\">\n";
@@ -143,7 +143,7 @@ function secupress_wp_version_iis7_rules() {
 function secupress_wp_version_nginx_rules() {
 	$marker  = 'wp_version';
 	$bases   = secupress_get_rewrite_bases();
-	$pattern = $bases['site_dir'] . 'readme.html';
+	$pattern = $bases['site_from'] . 'readme.html';
 
 	// - http://nginx.org/en/docs/http/ngx_http_core_module.html#location
 	$rules  = "


### PR DESCRIPTION
In the discloses scan, the discloses plugin, and the readmes plugin, used:
- `site_url()` instead of `home_url()` to get readme.html URL,
- `site_from` instead of `home_from` or `site_dir` for the rewrite rules.