### PR TITLE
Fixes SEC-413: Check for PHP and WP version on activation

### DIFF
--- a/secupress.php
+++ b/secupress.php
@@ -86,8 +86,6 @@ add_action( 'plugins_loaded', 'secupress_init', 0 );
  * @since 1.0
  */
 function secupress_init() {
-	global $wp_version;
-
 	// Nothing to do if autosave.
 	if ( defined( 'DOING_AUTOSAVE' ) ) {
 		return;
@@ -95,20 +93,6 @@ function secupress_init() {
 
 	// Load translations.
 	secupress_load_plugin_textdomain_translations();
-
-	// Check php version.
-	if ( version_compare( phpversion(), SECUPRESS_PHP_MIN ) < 0 ) {
-		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-		deactivate_plugins( plugin_basename( SECUPRESS_FILE ) );
-		wp_die( sprintf( __( '<strong>%1$s</strong> requires PHP %2$s minimum, your website is actually running version %3$s.', 'secupress' ), 'SecuPress', '<code>' . SECUPRESS_PHP_MIN . '</code>', '<code>' . phpversion() . '</code>' ) );
-	}
-
-	// Check WordPress version.
-	if ( version_compare( $wp_version, SECUPRESS_WP_MIN ) < 0 ) {
-		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-		deactivate_plugins( plugin_basename( SECUPRESS_FILE ) );
-		wp_die( sprintf( __( '<strong>%1$s</strong> requires WordPress %2$s minimum, your website is actually running version %3$s.', 'secupress' ), 'SecuPress', '<code>' . SECUPRESS_WP_MIN . '</code>', '<code>' . $wp_version . '</code>' ) );
-	}
 
 	// Functions.
 	secupress_load_functions();
@@ -273,10 +257,11 @@ function secupress_load_plugins() {
  * Include files that contain our functions.
  *
  * @since 1.2.3
+ * @since 1.2.5 Includes requirement checks.
  * @author Grégory Viguier
  */
 function secupress_load_functions() {
-	global $is_iis7;
+	global $is_iis7, $wp_version;
 	static $done = false;
 
 	if ( $done ) {
@@ -284,6 +269,40 @@ function secupress_load_functions() {
 	}
 	$done = true;
 
+	/**
+	 * Check requirements.
+	 */
+	// Check php version.
+	if ( version_compare( phpversion(), SECUPRESS_PHP_MIN ) < 0 ) {
+		$plugin = plugin_basename( SECUPRESS_FILE );
+
+		if ( 'activate_' . $plugin !== current_filter() ) {
+			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+			deactivate_plugins( SECUPRESS_FILE, true );
+		}
+
+		secupress_load_plugin_textdomain_translations();
+
+		wp_die( sprintf( __( '<strong>%1$s</strong> requires PHP %2$s minimum, your website is actually running version %3$s.', 'secupress' ), 'SecuPress', '<code>' . SECUPRESS_PHP_MIN . '</code>', '<code>' . phpversion() . '</code>' ) );
+	}
+
+	// Check WordPress version.
+	if ( version_compare( $wp_version, SECUPRESS_WP_MIN ) < 0 ) {
+		$plugin = plugin_basename( SECUPRESS_FILE );
+
+		if ( 'activate_' . $plugin !== current_filter() ) {
+			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+			deactivate_plugins( SECUPRESS_FILE, true );
+		}
+
+		secupress_load_plugin_textdomain_translations();
+
+		wp_die( sprintf( __( '<strong>%1$s</strong> requires WordPress %2$s minimum, your website is actually running version %3$s.', 'secupress' ), 'SecuPress', '<code>' . SECUPRESS_WP_MIN . '</code>', '<code>' . $wp_version . '</code>' ) );
+	}
+
+	/**
+	 * Require our functions.
+	 */
 	require_once( SECUPRESS_INC_PATH . 'functions/compat.php' );
 	require_once( SECUPRESS_INC_PATH . 'functions/deprecated.php' );
 	require_once( SECUPRESS_INC_PATH . 'functions/common.php' );


### PR DESCRIPTION
Included WP and php version checks inside `secupress_load_functions()`, so they are made before including any file, aka: on page load, on plugin activation, on plugin deactivation.
Also:
- `deactivate_plugins()` is triggered only if we are not activating the plugin, it would be useless.
- `deactivate_plugins()` is used "silently", otherwise it will trigger our deactivation hooks.
- We load our translations on the fly for the message.