### PR TITLE
Re-enable Secure Messaging

### DIFF
--- a/inc/data/no-longer-in-directory-plugin-list.data
+++ b/inc/data/no-longer-in-directory-plugin-list.data
@@ -11468,7 +11468,6 @@ secure-contact-form
 secure-files
 secure-form-mailer
 secure-hidden-login
-secure-messaging
 secure-wp
 secure-wp-api
 securepress


### PR DESCRIPTION
While helping a client update software on their site, I saw a note on the plugins page encouraging them to remove _my_ plugin, Secure Messaging. The notice claimed that my plugin either:
- had a security flaw
- was removed on my request
- wasn't GPL compatible
- or was under investigation

_None of these statements are true!_

Seeing a security plugin actively encourage end users to delete another, actively supported security plugin is potentially harmful in the community. This PR removes `secure-messaging` from the list of "removed plugins" to dismiss the following notice:

> SecuPress invites you to delete this plugin, no patch has been made by its author.