### PR TITLE
Sensitive Data / XML-RPC: return HTTP response code matching the data passed to secupress_die

### DIFF
--- a/inc/functions/common.php
+++ b/inc/functions/common.php
@@ -373,6 +373,9 @@ function secupress_die( $message = '', $title = '', $args = array() ) {
 			// Tell cache plugins not to cache our error message.
 			define( 'DONOTCACHEPAGE', true );
 		}
+		if ( ! empty( $args['response'] ) ) {
+			http_response_code( absint( $args['response'] ) );
+		}
 		wp_die( $message, $title, $args );
 	}
 }


### PR DESCRIPTION
### Changements proposés dans ce PR

J'ai essayé de détailler mon approche ci-dessous, dans le message du commit :

**********

When calling `secupress_die`, one has the option to provide a response code in the array of arguments passed to the function.
That response code can be useful as it offers us a way to having an HTTP response code that matches the response we want to send.

It's especially important when using SecuPress' XML-RPC options in its Sensitive Data module. That option allows us to block XML-RPC, which works well with the `wp_die` function. However, the response code is only used and returned by WordPress when $wp_xmlrpc_server has been set:
https://github.com/WordPress/WordPress/blob/0050998801cabab21245452be315236d7d84da6b/wp-includes/functions.php#L3716
This is not the case here in `secupress_die`. As a result, we end up blocking XML-RPC while still returning a 200 response code.

**This commit changes that and will return a 403 response code for XML-RPC requests made to a site using SecuPress.**

**********

### Comment tester

1. Sur un nouveau site avec SecuPress installé, aller dans SecuPress > Modules > Sensitive Data
2. Dans un terminal effectuer une requête vers XML-RPC:
```
$ curl -I https://monsite.com/xmlrpc.php
HTTP/2 405
server: nginx
date: Fri, 19 Jun 2020 11:22:13 GMT
content-type: text/plain;charset=UTF-8
allow: POST
```
3. De retour dans wp-admin, bloquer les requêtes XML-RPC.
4. Effectuer la requête une nouvelle fois.
```
$ curl -I https://monsite.com/xmlrpc.php
HTTP/2 200
server: nginx
date: Fri, 19 Jun 2020 11:23:48 GMT
content-type: text/html; charset=UTF-8
vary: Accept-Encoding
expires: Wed, 11 Jan 1984 05:00:00 GMT
cache-control: no-cache, must-revalidate, max-age=0
```
5. Mettre à jour SecuPress pour utiliser la branche de ce PR.
6. Effectuer la requête une nouvelle fois.
```
$ curl -I https://monsite.com/xmlrpc.php
HTTP/2 403
server: nginx
date: Fri, 19 Jun 2020 11:24:56 GMT
content-type: text/html; charset=UTF-8
vary: Accept-Encoding
expires: Wed, 11 Jan 1984 05:00:00 GMT
cache-control: no-cache, must-revalidate, max-age=0
```