### PR TITLE
Avoid bypass with URL encoded parameters

### DIFF
--- a/free/modules/users-login/plugins/stop-user-enumeration.php
+++ b/free/modules/users-login/plugins/stop-user-enumeration.php
@@ -82,7 +82,7 @@ add_filter( 'rest_request_before_callbacks', 'secupress_stop_user_enumeration_re
  * @author Julio Potier
  **/
 function secupress_stop_user_enumeration_rest( $response ) {
-	if ( ! current_user_can( 'list_users' ) && strpos( secupress_get_current_url( 'raw' ), Secupress_WP_REST_Users_Controller::get_rest_base() ) > 0 ) {
+	if ( ! current_user_can( 'list_users' ) && strpos( rawurldecode( secupress_get_current_url( 'raw' ) ), Secupress_WP_REST_Users_Controller::get_rest_base() ) > 0 ) {
 		wp_send_json( array( 'code' => 'rest_cannot_access', 'message' => __( 'Something went wrong.', 'secupress' ), 'data' => array( 'status' => 401 ) ) , 401 );
 	}
     return $response;


### PR DESCRIPTION
During an audit, I came across SecuPress and was able to retrieve the list of accounts by URL encoding the characters in the parameters.

![image](https://github.com/JulioPotier/secupress/assets/52674895/9a203b30-70e1-4f75-9438-a97dcb787727)

This PR, simply decodes the URL to avoid this bypass.
Here's the result after applying the patch.

![image](https://github.com/JulioPotier/secupress/assets/52674895/5f7c4ee8-fa06-481a-b4a5-d0daab6bd8e3)
